### PR TITLE
1.1.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.1.0-beta]
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ AF Portability is the web service that enables the end-user to extract/export th
 
 ## Versions, current dev state and future
 
-1.0.0-beta
+1.1.0-beta
 
 ## Getting started
 

--- a/jobtechdev.md
+++ b/jobtechdev.md
@@ -8,7 +8,7 @@ Gravity Portability is the web service that enables the end-user to extract/expo
 
 ##### Versions, current dev state and future
 
-1.0.0-beta
+1.1.0-beta
 
 ##### Getting started
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>se.arbetsformedlingen.matchning.portability</groupId>
 	<artifactId>profile2hropen</artifactId>
-	<version>1.0.0-beta</version>
+	<version>1.1.0-beta</version>
 	<packaging>jar</packaging>
 
 	<name>profile2hropen</name>


### PR DESCRIPTION
### Added

- HROpen 4.2-1
- Automatic generation of HROpen DTOs
- Builder functions for the needed HROpen classes
- Added Actuator endpoint on separate port (default 9804). Actuator port is intended to be used in internal network, not exposed to the public.
- New endpoint: "/checkCompatability"

### Deprecated

- Old mapping functions
- Some of the output names have been altered
- Removed 'personnummer' to 'legalId' mapping.