### PR TITLE
Forrr sanitize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.DS_Store
 .idea/
 target/
 .classpath

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>se.arbetsformedlingen.matchning.portability</groupId>
@@ -14,7 +15,7 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>2.0.5.RELEASE</version>
-        <relativePath /> <!-- lookup parent from repository -->
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
     <properties>
@@ -88,10 +89,10 @@
         </dependency>
 
         <dependency>
-			<groupId>org.json</groupId>
-			<artifactId>json</artifactId>
-			<version>20200518</version>
-		</dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20200518</version>
+        </dependency>
 
         <!-- Swagger -->
         <dependency>
@@ -115,6 +116,18 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+            <artifactId>owasp-java-html-sanitizer</artifactId>
+            <version>20200713.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/se/arbetsformedlingen/matchning/portability/JsonSanitizer.java
+++ b/src/main/java/se/arbetsformedlingen/matchning/portability/JsonSanitizer.java
@@ -1,0 +1,63 @@
+package se.arbetsformedlingen.matchning.portability;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.owasp.html.PolicyFactory;
+
+import java.util.Iterator;
+
+public class JsonSanitizer {
+    public static String sanitize(final PolicyFactory policy, final String input) {
+        return policy.sanitize(input);
+    }
+
+    public static void processObject(final PolicyFactory policy, final JsonNode inputNode, final JsonNode outputNode) {
+        inputNode.fields().forEachRemaining(entry -> {
+            final String entryKey = entry.getKey();
+            final JsonNode entryNode = entry.getValue();
+
+            if (entryNode.isObject()) {
+                final JsonNode element = ((ObjectNode) outputNode).putObject(entryKey);
+                processObject(policy, entryNode, element);
+            } else if (entryNode.isArray()) {
+                final JsonNode array = ((ObjectNode) outputNode).putArray(entryKey);
+                processArray(policy, entryNode, array);
+            } else if (entryNode.isTextual()) {
+                processTextual(policy, inputNode, outputNode, entryKey);
+            } else {
+                processOther(policy, inputNode, outputNode, entryKey);
+            }
+        });
+    }
+
+    public static void processArray(final PolicyFactory policy, final JsonNode inputNode, final JsonNode outputNode) {
+
+        final ArrayNode arrayNode = (ArrayNode) inputNode;
+
+        final Iterator<JsonNode> node = arrayNode.elements();
+        while (node.hasNext()) {
+            final JsonNode entryNode = node.next();
+
+            if (entryNode.isObject()) {
+                final JsonNode element = ((ArrayNode) outputNode).addObject();
+                processObject(policy, entryNode, element);
+            } else if (entryNode.isArray()) {
+                final JsonNode array = ((ArrayNode) outputNode).addArray();
+                processArray(policy, entryNode, array);
+            } else if (entryNode.isTextual()) {
+                ((ArrayNode) outputNode).add(sanitize(policy, entryNode.asText()));
+            } else {
+                ((ArrayNode) outputNode).add(entryNode);
+            }
+        }
+    }
+
+    public static void processTextual(final PolicyFactory policy, final JsonNode inputNode, final JsonNode outputNode, final String key) {
+        ((ObjectNode) outputNode).put(key, sanitize(policy, inputNode.get(key).asText()));
+    }
+
+    public static void processOther(final PolicyFactory policy, final JsonNode inputNode, final JsonNode outputNode, final String key) {
+        ((ObjectNode) outputNode).set(key, inputNode.get(key));
+    }
+}

--- a/src/main/java/se/arbetsformedlingen/matchning/portability/repository/AspRespository.java
+++ b/src/main/java/se/arbetsformedlingen/matchning/portability/repository/AspRespository.java
@@ -1,6 +1,7 @@
 package se.arbetsformedlingen.matchning.portability.repository;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -8,14 +9,18 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
-import se.arbetsformedlingen.matchning.portability.dto.CandidateType;
+import se.arbetsformedlingen.matchning.portability.JsonSanitizer;
 import se.arbetsformedlingen.matchning.portability.builder.CandidateTypeBuilder;
-import se.arbetsformedlingen.matchning.portability.model.asp.*;
+import se.arbetsformedlingen.matchning.portability.dto.CandidateType;
+import se.arbetsformedlingen.matchning.portability.model.asp.ArbetsSokandeProfil;
+import se.arbetsformedlingen.matchning.portability.model.asp.PersonUppgifter;
 import se.arbetsformedlingen.matchning.taxonomy.repository.Taxonomies;
 
 import java.io.IOException;
@@ -29,58 +34,71 @@ public class AspRespository {
 
     //@Value("${spring.kundgift.url}")
     private static String KUNDUPPGIFT_URL; //= "http://arbetssokande.arbetsformedlingen.se:80/arbetssokande/rest/af/v1/arbetssokande/externa-personuppgifter";
-
-    private Logger LOG = LoggerFactory.getLogger(AspRespository.class);
-
     @Autowired
     ObjectMapper mapper;
-
     @Autowired
     Taxonomies taxonomyRepository;
+    private final Logger LOG = LoggerFactory.getLogger(AspRespository.class);
 
     AspRespository(
-            @Value("${spring.profile.url}") String profilUrl,
-            @Value("${spring.kundgift.url}") String kundgiftUrl
+            @Value("${spring.profile.url}") final String profilUrl,
+            @Value("${spring.kundgift.url}") final String kundgiftUrl
     ) {
         PROFIL_URL = profilUrl;
         KUNDUPPGIFT_URL = kundgiftUrl;
     }
 
-    public CandidateType getCandidateForToken(String token) {
+    public CandidateType getCandidateForToken(final String token) {
         CandidateType candidate = null;
         try {
             String results = readFromAPI(PROFIL_URL, token);
-            List<ArbetsSokandeProfil> profiler = mapper.readValue(results, new TypeReference<List<ArbetsSokandeProfil>>() {
+
+            final PolicyFactory policy = new HtmlPolicyBuilder()
+                    .allowElements("a")
+                    .allowUrlProtocols("https")
+                    .allowAttributes("href").onElements("a")
+                    .requireRelNofollowOnLinks()
+                    .toFactory();
+
+            final ObjectMapper om = new ObjectMapper();
+
+            final JsonNode inputNode = om.readTree(results);
+            final JsonNode outputNode = om.createArrayNode();
+
+            JsonSanitizer.processArray(policy, inputNode, outputNode);
+            final String actual = om.writeValueAsString(outputNode);
+
+            final List<ArbetsSokandeProfil> profiler = mapper.readValue(actual, new TypeReference<List<ArbetsSokandeProfil>>() {
             });
             results = readFromAPI(KUNDUPPGIFT_URL, token);
-            PersonUppgifter personUppgifter = mapper.readValue(results, PersonUppgifter.class);
+
+            final PersonUppgifter personUppgifter = mapper.readValue(results, PersonUppgifter.class);
 
             candidate = new CandidateTypeBuilder()
                     .withPersonUppgifter(personUppgifter)
                     .withProfiles(profiler)
                     .build();
 
-        } catch (HttpException he) {
-            LOG.error("Request to " + he.getURL() + " failed ("+ he.getStatusCode() + ")");
+        } catch (final HttpException he) {
+            LOG.error("Request to " + he.getURL() + " failed (" + he.getStatusCode() + ")");
 
-        } catch (IOException e) {
+        } catch (final IOException e) {
             throw new RuntimeException(e);
         }
         return candidate;
     }
 
 
-
-    private String readFromAPI(String apiUrl, String token) throws IOException {
-        HttpGet httpGet = new HttpGet(apiUrl);
+    private String readFromAPI(final String apiUrl, final String token) throws IOException {
+        final HttpGet httpGet = new HttpGet(apiUrl);
         httpGet.setHeader("X-JWT-Assertion", token);
-        HttpClient client = HttpClients.createDefault();
-        HttpResponse response = client.execute(httpGet);
+        final HttpClient client = HttpClients.createDefault();
+        final HttpResponse response = client.execute(httpGet);
         if (response.getStatusLine().getStatusCode() != 200) {
             throw new HttpException(response.getStatusLine().getStatusCode(), apiUrl);
         }
-        HttpEntity entity = response.getEntity();
-        String results = EntityUtils.toString(entity);
+        final HttpEntity entity = response.getEntity();
+        final String results = EntityUtils.toString(entity);
         return results;
     }
 }

--- a/src/test/java/se/arbetsformedlingen/matchning/portability/SanitizeTest.java
+++ b/src/test/java/se/arbetsformedlingen/matchning/portability/SanitizeTest.java
@@ -1,0 +1,40 @@
+package se.arbetsformedlingen.matchning.portability;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class SanitizeTest {
+
+    @Test
+    public void test() throws JsonParseException, IOException {
+        final String original = "{\"hello\":true,\"foo\":{\"bar\":\"Hello<script>baz</script>\"},\"lorem\":[\"ipsum\",\"dolor\",\"sit\",\"amet\"]}";
+        final String expected = "{\"hello\":true,\"foo\":{\"bar\":\"Hello\"},\"lorem\":[\"ipsum\",\"dolor\",\"sit\",\"amet\"]}";
+
+        final PolicyFactory policy = new HtmlPolicyBuilder()
+                .allowElements("a")
+                .allowUrlProtocols("https")
+                .allowAttributes("href").onElements("a")
+                .requireRelNofollowOnLinks()
+                .requireRelNofollowOnLinks()
+                .toFactory();
+
+        final ObjectMapper om = new ObjectMapper();
+
+        final JsonNode inputNode = om.readTree(original); // Load data to work on
+        final JsonNode outputNode = om.createObjectNode();
+
+
+        JsonSanitizer.processObject(policy, inputNode, outputNode);
+        final String actual = om.writeValueAsString(outputNode);
+
+        assertEquals(expected, actual); // Output stream expected to match expected
+    }
+}


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the [contribution guidelines](CONTRIBUTING.md), then fill out the blanks below.)

---

The new "JsonSanitizer" Java class in af-portability implements sanitation of JSON formatted data, meaning that each JSON node of the data passes through a formatter (OWASP Java HTML Sanitizer) that removes what it deems inappropriate content. See https://github.com/OWASP/java-html-sanitizer
This can improve resistance against XSS (Cross Site Scripting) attacks.

That class is generally applicable to any application where JSON data is received
 so could be an asset to re-use by other projects.
...

Closes the Af Connect project task of "Evaluate and Implement penetration test suggestions".
...

The implemented "SanitizeTest.java" runs successfully.

...

Tested so far on MacOS Catalina 10.15.7, Chrome browser 89.0.4389.114